### PR TITLE
Swap season number and episode number in 'Watching Now'

### DIFF
--- a/Traktoid/src/com/florianmski/tracktoid/ui/fragments/HomeFragment.java
+++ b/Traktoid/src/com/florianmski/tracktoid/ui/fragments/HomeFragment.java
@@ -212,7 +212,7 @@ public class HomeFragment extends TraktFragment implements onDashboardButtonClic
 					episode = checkin.episode;
 					rlWatchingNow.setVisibility(View.VISIBLE);
 					tvEpisodeTitle.setText(episode.title);
-					tvEpisodeEpisode.setText(Utils.addZero(episode.number) + "x" + Utils.addZero(episode.season));
+					tvEpisodeEpisode.setText(Utils.addZero(episode.season) + "x" + Utils.addZero(episode.number));
 					Image i = new Image(checkin.show.tvdbId, episode.images.screen, episode.season, episode.number);
 					final AQuery aq = new AQuery(getActivity());
 					BitmapAjaxCallback cb = new BitmapAjaxCallback()


### PR DESCRIPTION
Any particular reason it's set to [episode]x[season] instead of [season]x[episode]? That's usually the convention used.
